### PR TITLE
Update top-level catalogues for new naming convention

### DIFF
--- a/configurations/catalogue_ceda.json
+++ b/configurations/catalogue_ceda.json
@@ -1,6 +1,6 @@
 {
   "id": "ceda-harvester",
   "url": "https://api.stac.ceda.ac.uk/",
-  "path": "public/ceda-stac-catalogue2",
+  "path": "public/ceda",
   "schedule": "58 15 * * *"
 }

--- a/configurations/catalogue_ceda.json
+++ b/configurations/catalogue_ceda.json
@@ -1,6 +1,6 @@
 {
   "id": "ceda-harvester",
   "url": "https://api.stac.ceda.ac.uk/",
-  "path": "supported-datasets/ceda-stac-catalogue2",
+  "path": "public/ceda-stac-catalogue2",
   "schedule": "58 15 * * *"
 }

--- a/configurations/e84.json
+++ b/configurations/e84.json
@@ -1,6 +1,6 @@
 {
   "id": "element-84",
   "url": "https://earth-search.aws.element84.com/v1",
-  "path": "supported-datasets/earth-search-aws",
+  "path": "public/earth-search-aws",
   "schedule": "12 11 * * *"
 }

--- a/configurations/e84.json
+++ b/configurations/e84.json
@@ -1,6 +1,6 @@
 {
   "id": "element-84",
   "url": "https://earth-search.aws.element84.com/v1",
-  "path": "public/earth-search-aws",
+  "path": "public/element84",
   "schedule": "12 11 * * *"
 }

--- a/configurations/test_catalogue_cmip6.json
+++ b/configurations/test_catalogue_cmip6.json
@@ -1,6 +1,6 @@
 {
     "id": "ceda-harvester",
     "url": "https://api.stac.ceda.ac.uk/collections/cmip6",
-    "path": "supported-datasets/ceda-stac-catalogue/cmip6",
+    "path": "public/ceda-stac-catalogue/cmip6",
     "schedule": "10 08 * * *"
 }

--- a/configurations/test_catalogue_cmip6.json
+++ b/configurations/test_catalogue_cmip6.json
@@ -1,6 +1,6 @@
 {
     "id": "ceda-harvester",
     "url": "https://api.stac.ceda.ac.uk/collections/cmip6",
-    "path": "public/ceda-stac-catalogue/cmip6",
+    "path": "public/ceda/cmip6",
     "schedule": "10 08 * * *"
 }

--- a/configurations/test_catalogue_sentinel1.json
+++ b/configurations/test_catalogue_sentinel1.json
@@ -1,6 +1,6 @@
 {
   "id": "ceda-harvester",
   "url": "https://api.stac.ceda.ac.uk/collections/sentinel1",
-  "path": "public/ceda-stac-catalogue/sentinel1",
+  "path": "public/ceda/sentinel1",
   "schedule": "10 11 * * *"
 }

--- a/configurations/test_catalogue_sentinel1.json
+++ b/configurations/test_catalogue_sentinel1.json
@@ -1,6 +1,6 @@
 {
   "id": "ceda-harvester",
   "url": "https://api.stac.ceda.ac.uk/collections/sentinel1",
-  "path": "supported-datasets/ceda-stac-catalogue/sentinel1",
+  "path": "public/ceda-stac-catalogue/sentinel1",
   "schedule": "10 11 * * *"
 }

--- a/configurations/test_catalogue_sentinel2_ard.json
+++ b/configurations/test_catalogue_sentinel2_ard.json
@@ -1,6 +1,6 @@
 {
   "id": "ceda-harvester",
   "url": "https://api.stac.ceda.ac.uk/collections/sentinel2_ard",
-  "path": "supported-datasets/ceda-stac-catalogue/sentinel2_ard",
+  "path": "public/ceda-stac-catalogue/sentinel2_ard",
   "schedule": "0 11 * * *"
 }

--- a/configurations/test_catalogue_sentinel2_ard.json
+++ b/configurations/test_catalogue_sentinel2_ard.json
@@ -1,6 +1,6 @@
 {
   "id": "ceda-harvester",
   "url": "https://api.stac.ceda.ac.uk/collections/sentinel2_ard",
-  "path": "public/ceda-stac-catalogue/sentinel2_ard",
+  "path": "public/ceda/sentinel2_ard",
   "schedule": "0 11 * * *"
 }


### PR DESCRIPTION
## Update root catalogs to align with new catalogue structure
- `supported-datasets` now harvested into `public` top-level catalog